### PR TITLE
fixes #4: rollable overhaul (add rollConfig item type and rollResult partial)

### DIFF
--- a/css/fvtt-2n.css
+++ b/css/fvtt-2n.css
@@ -8,6 +8,9 @@
 /* item sheets */
 @import url('gear-sheet.css');
 
+/* rollResult */
+@import url('rollResult.css');
+
 /* tools */
 @import url('tools/itemTable.css');
 

--- a/css/rollResult.css
+++ b/css/rollResult.css
@@ -1,0 +1,4 @@
+.rollResult-mods th:not(:first-child),
+.rollResult-mods td:not(:first-child) {
+    text-align: right;
+}

--- a/css/tools/itemTable.css
+++ b/css/tools/itemTable.css
@@ -35,6 +35,10 @@
     width: 2em !important;
 }
 
+.itemTable-inputRoll {
+    width: 4em !important;
+}
+
 .itemTable-handle[data-locked="true"] {
     color: darkgray;
     cursor: default;

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "2n",
     "description": "@koibu0 's modifications to the second edition of the world's greatest roleplaying game",
     "license": "MPL-2.0",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "authors": [
       {
         "name": "Luke Lavan",
@@ -12,7 +12,7 @@
     ],
     "compatibility": {
       "minimum": "10",
-      "verified": "10.286",
+      "verified": "10.287",
       "maximum": "10"
     },
     "esmodules": ["system/fvtt-2n.mjs"],

--- a/system/fvtt-2n.mjs
+++ b/system/fvtt-2n.mjs
@@ -3,6 +3,9 @@ import {TwoNActorSheet} from './actor-sheet.mjs';
 
 import {TwoNItem} from './item.mjs';
 import {TwoNItemSheet} from './item-sheet.mjs';
+import {TwoNRollConfigSheet} from './rollConfig-sheet.mjs';
+
+import {rollResultActivateListeners} from './rollResultActivateListeners.mjs';
 
 import {registerAllPartials} from '../templates/partials/registerAllPartials.js';
 
@@ -32,6 +35,11 @@ Hooks.once('init', async function () {
     });
     Items.unregisterSheet('core', ItemSheet);
     Items.registerSheet('fvtt-2n', TwoNItemSheet, {
+        types: ['gear', 'spell', 'weapon'],
+        makeDefault: true,
+    });
+    Items.registerSheet('fvtt-2n', TwoNRollConfigSheet, {
+        types: ['rollConfig'],
         makeDefault: true,
     });
 
@@ -77,3 +85,8 @@ Hooks.on('renderDialog', function (dialog, html) {
 
 // add items to new actors
 Hooks.on('createActor', createActor);
+
+Hooks.on('renderChatMessage', (message, html, data) => {
+    if (message.getFlag('fvtt-2n', 'rollResult'))
+        rollResultActivateListeners(message, html, data);
+});

--- a/system/item-sheet.mjs
+++ b/system/item-sheet.mjs
@@ -20,4 +20,8 @@ export class TwoNItemSheet extends ItemSheet {
         );
         return data;
     }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+    }
 }

--- a/system/rollConfig-sheet.mjs
+++ b/system/rollConfig-sheet.mjs
@@ -1,0 +1,215 @@
+import {TwoNItemSheet} from './item-sheet.mjs';
+
+export class TwoNRollConfigSheet extends TwoNItemSheet {
+    static get defaultOptions() {
+        return mergeObject(super.defaultOptions, {
+            classes: ['TwoN', 'sheet', 'item'],
+            width: 360,
+            height: 420,
+            tabs: [],
+        });
+    }
+
+    get template() {
+        return `systems/fvtt-2n/templates/rollConfig-sheet.html`;
+    }
+
+    async getData(options) {
+        const data = await super.getData(options);
+        data.enrichedHTML = await TextEditor.enrichHTML(
+            this.object.system.description,
+            {async: true}
+        );
+        return data;
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+        html.find('.rollMod-create').click(this.rollModCreate.bind(this));
+        html.find('.rollMod-edit').change(this.rollModEdit.bind(this));
+        html.find('.rollMod-delete').click(this.rollModDelete.bind(this));
+        html.find('.rollMod-lock').click(this.rollModLock.bind(this));
+        html.find('.roll').click(this.roll.bind(this));
+
+        html.find('.itemTable-sort').map((_i, el) => {
+            // eslint-disable-next-line no-undef
+            Sortable.create(el, {
+                onUpdate: this._onUpdateDrag.bind(this),
+                handle: '.itemTable-handle',
+                filter: '[data-locked="true"]',
+            });
+        });
+    }
+
+    /**
+     * calls this.actor.update and updates parent actor's rollConfig item (this)
+     * to use the given mods array
+     */
+    async _updateMods(mods) {
+        await this.actor.update({
+            items: [
+                {
+                    _id: this.item.id,
+                    'system.mods': mods,
+                },
+            ],
+        });
+    }
+
+    /** also triggers this.render() */
+    async rollModCreate() {
+        const mods = this.item.system.mods;
+        mods.push({
+            name: 'New modifier',
+            mod: '',
+            roll: undefined,
+            active: true,
+            locked: false,
+        });
+        await this._updateMods(mods);
+        this.render();
+    }
+
+    /** does not trigger this.render() */
+    async rollModEdit(event) {
+        const currentTarget = $(event.currentTarget);
+        const index = currentTarget.data('index');
+        const target = currentTarget.data('target');
+        let value = currentTarget.val();
+
+        // ensure checkbox values are booleans
+        if (currentTarget.attr('type') === 'checkbox') {
+            if (currentTarget.is(':checked')) value = true;
+            else value = false;
+        }
+
+        const mods = this.item.system.mods;
+        mods[index][target] = value;
+
+        await this._updateMods(mods);
+    }
+
+    /** also triggers this.render() */
+    async rollModDelete(event) {
+        const currentTarget = $(event.currentTarget);
+        const index = currentTarget.data('index');
+
+        let mods = this.item.system.mods;
+        if (mods.length === 1) mods = [];
+        else mods.splice(index, index);
+
+        await this._updateMods(mods);
+        this.render();
+    }
+
+    /** also triggers this.render() */
+    async rollModLock(event) {
+        const currentTarget = $(event.currentTarget);
+        const index = currentTarget.data('index');
+
+        const mods = this.item.system.mods;
+        mods[index].locked = !mods[index].locked;
+
+        await this._updateMods(mods);
+        this.render();
+    }
+
+    /**
+     * @param {number} total the final result of the roll; left side of comparison
+     * @param {string} comparison encodes the desired comparison type, e.g. '>='
+     * @param {number} target right side of comparison
+     *
+     * @return {boolean} result of comparison
+     */
+    _rollDetermineSuccess(total, comparison, target) {
+        switch (comparison) {
+            case '>':
+                return total > target;
+            case '>=':
+                return total >= target;
+            case '<':
+                return total < target;
+            case '<=':
+                return total <= target;
+            case '==':
+                return total == target;
+            case '!=':
+                return total != target;
+        }
+    }
+
+    async roll() {
+        const mods = this.item.system.mods;
+        /** the final value to add to the roll, evaluating all sub-rolls */
+        let sumMod = 0;
+        /** a string representing the sum value of mods, adding flat values and preserving subrolls */
+        let strMod = '';
+        /** the sum value of all flat mods (ie, only mods such that isNaN(mod)) */
+        let sumModFlat = 0;
+
+        for (let i = 0; i < mods.length; ++i) {
+            if (!mods[i].active) continue;
+            // evaluate each mod as a new roll, coercing numbers to strings
+            mods[i].roll = new Roll('' + mods[i].mod);
+            await mods[i].roll.evaluate({async: true});
+            sumMod += mods[i].roll.total;
+
+            // build strMod
+            // TODO: combine like terms of dice ('d6 + 2d6 - 2d6' -> '3d6 - 2d6')
+            //       positive dice and negative dice shouldn't combine
+            if (isNaN(mods[i].mod)) {
+                if (strMod === '') strMod = mods[i].mod;
+                else {
+                    if (mods[i].mod.charAt(0) != '-')
+                        strMod += ' + ' + mods[i].mod;
+                    else strMod += ' - ' + mods[i].mod.substring(1);
+                }
+            } else sumModFlat += +mods[i].mod; // all flat mods are combined
+        }
+
+        if (sumModFlat != 0)
+            strMod +=
+                (strMod === '' ? '' : sumModFlat > 0 ? ' + ' : ' - ') +
+                Math.abs(sumModFlat);
+
+        let roll = new Roll(this.item.system.roll + '+' + sumMod);
+        await roll.evaluate({async: true});
+
+        let success;
+        if (this.item.system.comparison)
+            success = this._rollDetermineSuccess(
+                roll.total,
+                this.item.system.comparison,
+                this.item.system.target
+            );
+
+        const html = await renderTemplate(
+            'systems/fvtt-2n/templates/rollResult.html',
+            {
+                roll,
+                rollConfig: this.item.system,
+                sumMod,
+                success,
+            }
+        );
+
+        return ChatMessage.create({
+            flavor: `<h3>${this.item.name}: ${
+                this.item.system.roll + (strMod ? ' + ' + strMod : '')
+            }</h3>`,
+            content: html,
+            'flags.fvtt-2n.rollResult': true,
+        });
+    }
+
+    _onUpdateDrag(event) {
+        const mods = this.item.system.mods;
+
+        mods.splice(
+            event.newDraggableIndex,
+            0,
+            mods.splice(event.oldDraggableIndex, 1)[0]
+        );
+        this._updateMods(mods);
+    }
+}

--- a/system/rollResultActivateListeners.mjs
+++ b/system/rollResultActivateListeners.mjs
@@ -1,0 +1,5 @@
+export const rollResultActivateListeners = (_message, html, _data) => {
+    html.find('.rollResult-collapse').click((_ev) => {
+        html.find('.rollResult-mods').toggle();
+    });
+};

--- a/template.json
+++ b/template.json
@@ -121,7 +121,7 @@
     }
   },
   "Item": {
-    "types": ["throwMod", "acMod", "hitMod", "gearTab", "gear", "nonWeaponProficiency", "weaponProficiency", "weapon", "spell"],
+    "types": ["throwMod", "acMod", "hitMod", "gearTab", "gear", "nonWeaponProficiency", "weaponProficiency", "weapon", "spell", "rollConfig"],
     "templates": {
       "base": {
         "locked": false,
@@ -212,6 +212,15 @@
       "verbal": true,
       "somatic": true,
       "material": false
+    },
+    "rollConfig": {
+      "rollid": "",
+      "mods": [],
+      "linkedid": "",
+      "roll": "",
+      "target": "",
+      "comparison": "",
+      "description": ""
     }
   }
 }

--- a/templates/partials/pc/basic.html
+++ b/templates/partials/pc/basic.html
@@ -282,8 +282,11 @@
             </div>
             <div 
                 class="rollable"
-                data-roll="d20cs<={{data.system.openDoors}}"
                 data-label="Open Doors Check"
+                data-rollid="openDoors"
+                data-roll="d20"
+                data-target="{{data.system.openDoors}}"
+                data-comparison="<="
             >
                 <span class="derived-label">
                     Open Doors
@@ -294,14 +297,17 @@
             </div>
             <div
                 class="rollable"
-                data-roll="d100cs<={{data.system.bendBars}}"
                 data-label="Bend Bars Check"
+                data-rollid="bendBars"
+                data-roll="d100"
+                data-target="{{data.system.bendBars}}"
+                data-comparison="<="
             >
                 <span class="derived-label">
                     Bend Bars
                 </span>
                 <span class="derived-value">
-                    {{data.system.bendBars}}
+                    {{data.system.bendBars}}%
                 </span>
             </div>
         </div>
@@ -376,14 +382,17 @@
             </div>
             <div
                 class="rollable"
-                data-roll="d100cs<={{data.system.spellLearnChance}}"
                 data-label="Chance to Learn Spell"
+                data-rollid="spellLearnChance"
+                data-roll="d100"
+                data-target="{{data.system.spellLearnChance}}"
+                data-comparison="<="
             >
                 <span class="derived-label">
                     Chance to Learn Spell
                 </span>
                 <span class="derived-value">
-                    {{data.system.spellLearnChance}}
+                    {{data.system.spellLearnChance}}%
                 </span>
             </div>
             <div>
@@ -414,14 +423,17 @@
             </div>
             <div
                 class="rollable"
-                data-roll="d100cs<={{data.system.chanceSpellFailure}}"
                 data-label="Spell Failure"
+                data-rollid="chanceSpellFailure"
+                data-roll="d100"
+                data-target="{{data.system.chanceSpellFailure}}"
+                data-comparison="<="
             >
                 <span class="derived-label">
                     Spell Failure
                 </span>
                 <span class="derived-value">
-                    {{data.system.chanceSpellFailure}}
+                    {{data.system.chanceSpellFailure}}%
                 </span>
             </div>
         </div>
@@ -444,8 +456,9 @@
             </div>
             <div
                 class="rollable"
-                data-roll="2d10+{{data.system.reactionAdjust}}"
                 data-label="Encounter Reaction"
+                data-rollid="reactionAdjust"
+                data-roll="2d10+{{data.system.reactionAdjust}}"
             >
                 <span class="derived-label">
                     Reaction Adjustment
@@ -458,8 +471,11 @@
         <div class="basic-derivedRow basic-derivedRow-altColor" id="derived-per">
             <div
                 class="rollable"
-                data-roll="d10cs>(3-{{data.system.surpriseAdjust}})"
                 data-label="Surprise Check"
+                data-rollid="surpriseAdjust"
+                data-roll="d10+{{data.system.surpriseAdjust}}"
+                data-target="3"
+                data-comparison=">"
             >
                 <span class="derived-label">
                     Surprise Adjustment

--- a/templates/partials/pc/combat.html
+++ b/templates/partials/pc/combat.html
@@ -2,8 +2,9 @@
     <div class="combat-top-hp">
         <span
             class="rollable"
-            data-roll="{{data.system.hitDieRoll}}+{{data.system.hitPointAdjust}}"
             data-label="Hit Die"
+            data-rollid="hitDieRoll"
+            data-roll="{{data.system.hitDieRoll}}+{{data.system.hitPointAdjust}}"
         >Hit Points</span>
         <hr />
         <div>
@@ -206,6 +207,9 @@
                 <td class="weapon-roll-td">
                     <a
                         class="rollable weapon-roll"
+                        data-linkedid="{{this.id}}"
+                        data-label="to hit with {{this.name}}"
+                        data-rollid="{{this.id}}-toHit"
                         data-roll="
                             1d20
                             +{{this.system.toHit}}
@@ -219,14 +223,16 @@
                                 +{{this.system.hitAdjust.thrown}}
                             {{/if}}
                         "
-                        data-label="to hit with {{this.name}}"
+                        
                     ></a>
                 </td>
                 <td class="weapon-roll-td">
                     <a
                         class="rollable weapon-roll"
-                        data-roll="{{this.system.damageRoll}}"
+                        data-linkedid="{{this.id}}"
                         data-label="damage with {{this.name}}"
+                        data-rollid="{{this.id}}-damageRoll"
+                        data-roll="{{this.system.damageRoll}}"
                     ></a>
                 </td>
             </tr>
@@ -249,8 +255,9 @@
                 <td>Melee</td>
                 <td
                     class="rollable combat-mid-throws-value combat-big-text"
-                    data-roll="d20+{{data.system.hitAdjust.melee}}"
                     data-label="Basic Melee Attack"
+                    data-rollid="hitMelee"
+                    data-roll="d20+{{data.system.hitAdjust.melee}}"
                 >
                     {{#if (gte data.system.hitAdjust.melee 0)}}+{{/if}}{{data.system.hitAdjust.melee}}
                 </td>
@@ -259,8 +266,9 @@
                 <td>Missile</td>
                 <td
                     class="rollable combat-mid-throws-value combat-big-text"
-                    data-roll="d20+{{data.system.hitAdjust.missile}}"
                     data-label="Basic Missile Attack"
+                    data-rollid="hitMissile"
+                    data-roll="d20+{{data.system.hitAdjust.missile}}"
                 >
                     {{#if (gte data.system.hitAdjust.missile 0)}}+{{/if}}{{data.system.hitAdjust.missile}}
                 </td>
@@ -269,8 +277,9 @@
                 <td>Thrown</td>
                 <td
                     class="rollable combat-mid-throws-value combat-big-text"
-                    data-roll="d20+{{data.system.hitAdjust.thrown}}"
                     data-label="Basic Thrown Attack"
+                    data-rollid="hitThrown"
+                    data-roll="d20+{{data.system.hitAdjust.thrown}}"
                 >
                     {{#if (gte data.system.hitAdjust.thrown 0)}}+{{/if}}{{data.system.hitAdjust.thrown}}
                 </td>
@@ -569,8 +578,11 @@
                 <!-- TODO: Constitution modifier for posion -->
                 <td
                     class="rollable combat-big-text combat-mid-throws-value"
-                    data-roll="d20cs>={{data.system.savingThrows.ppd}}"
                     data-label="Saving Throw against Paralyzation/Poison/Death"
+                    data-rollid="savePpd"
+                    data-roll="d20"
+                    data-comparison=">="
+                    data-target="{{data.system.savingThrows.ppd}}"
                 >
                     {{data.system.savingThrows.ppd}}
                 </td>
@@ -581,8 +593,11 @@
                 </td>
                 <td
                     class="rollable combat-big-text combat-mid-throws-value"
-                    data-roll="d20cs>={{data.system.savingThrows.rsw}}"
                     data-label="Saving Throw against Rods/Staves/Wands"
+                    data-rollid="saveRsw"
+                    data-roll="d20"
+                    data-comparison=">="
+                    data-target="{{data.system.savingThrows.rsw}}"
                 >
                     {{data.system.savingThrows.rsw}}
                 </td>
@@ -593,8 +608,11 @@
                 </td>
                 <td
                     class="rollable combat-big-text combat-mid-throws-value"
-                    data-roll="d20cs>={{data.system.savingThrows.pepo}}"
                     data-label="Saving Throw against Petrification/Polymorph"
+                    data-rollid="savePepo"
+                    data-roll="d20cs>="
+                    data-comparison=">="
+                    data-target="{{data.system.savingThrows.pepo}}"
                 >
                     {{data.system.savingThrows.pepo}}
                 </td>
@@ -605,8 +623,11 @@
                 </td>
                 <td
                     class="rollable combat-big-text combat-mid-throws-value"
-                    data-roll="d20cs>={{data.system.savingThrows.brw}}"
                     data-label="Saving Throw against Breath Weapon"
+                    data-rollid="saveBrw"
+                    data-roll="d20"
+                    data-comparison=">="
+                    data-target="{{data.system.savingThrows.brw}}"
                 >
                     {{data.system.savingThrows.brw}}
                 </td>
@@ -618,8 +639,11 @@
                 <!-- TODO: Wisdom modifier for "mind"-affecting spells -->
                 <td
                     class="rollable combat-big-text combat-mid-throws-value"
-                    data-roll="d20cs>={{data.system.savingThrows.spell}}"
                     data-label="Saving Throw against Spell"
+                    data-rollid="saveSpell"
+                    data-roll="d20"
+                    data-comparison=">="
+                    data-target="{{data.system.savingThrows.spell}}"
                 >
                     {{data.system.savingThrows.spell}}
                 </td>

--- a/templates/partials/pc/skills.html
+++ b/templates/partials/pc/skills.html
@@ -69,8 +69,11 @@
                 <td>
                     <span
                         class="rollable skills-rollSpan"
-                        data-roll="d20cs>=(20-{{this.system.total}})"
                         data-label="{{this.name}} Check"
+                        data-rollid="{{this.id}}.adjust"
+                        data-roll="d20+{{this.system.total}}"
+                        data-comparison=">="
+                        data-target="20"
                     >
                         {{this.system.total}}
                     </span>

--- a/templates/rollConfig-sheet.html
+++ b/templates/rollConfig-sheet.html
@@ -1,0 +1,73 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="rollMods" style="margin:5px;">
+        <table class="itemTable">
+            <tr>
+                <th colspan="5">Roll Modifiers</th>
+            </tr>
+            <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Mod</th>
+                <th>Active?</th>
+                <th></th>
+            </tr>
+            <tbody class="itemTable-sort">
+                {{#each data.system.mods}}
+                <tr data-locked="{{this.locked}}">
+                    <td>
+                        <a class="itemTable-handle">
+                            <i class="fas fa-bars"></i>
+                        </a>
+                    </td>
+                    <td>
+                        <input
+                            type="text"
+                            value="{{this.name}}"
+                            class="itemTable-inputText rollMod-edit"
+                            data-index="{{@index}}"
+                            data-target="name"
+                            {{#if this.locked}}disabled{{/if}}
+                        />
+                    </td>
+                    <td>
+                        <input
+                            type="text"
+                            value="{{this.mod}}"
+                            class="itemTable-inputRoll rollMod-edit"
+                            data-index="{{@index}}"
+                            data-target="mod"
+                            {{#if this.locked}}disabled{{/if}}
+                        />
+                    </td>
+                    <td>
+                        <input
+                            type="checkbox"
+                            {{checked this.active}}
+                            class="rollMod-edit"
+                            data-index="{{@index}}"
+                            data-target="active"
+                        />
+                    </td>
+                    <td>
+                        <a class="rollMod-delete" data-index="{{@index}}"
+                        >
+                            <i class="fas fa-trash"></i>
+                        </a>
+                        <a class="rollMod-lock" data-index="{{@index}}"
+                        >
+                            <i class="fas {{#if this.locked}} fa-lock {{else}} fa-lock-open {{/if}}"></i>
+                        </a>
+                    </td>
+                </tr>
+                {{/each}}
+            </tbody>
+        </table>
+        <div class="itemTable-buttons">
+            <a class="rollMod-create"><i class="fas fa-plus"></i> Add modifier</a>
+        </div>
+    </div>
+    {{#if data.system.comparison}}
+    <h3>Desired roll: {{data.system.comparison}} {{data.system.target}}</h3>
+    {{/if}}
+    <button class="roll">roll me</button>
+</form>

--- a/templates/rollResult.html
+++ b/templates/rollResult.html
@@ -1,0 +1,31 @@
+<button class="rollResult-collapse">collapse</button>
+<div class="rollResult-mods" style="display: none">
+    <table>
+        <tr>
+            <th>Modifier name</th>
+            <th>Roll</th>
+            <th>Val.</th>
+        </tr>
+        {{#each this.rollConfig.mods}}
+            {{#if this.active}}
+                <tr>
+                    <td>{{this.name}}</td>
+                    <td>{{this.mod}}</td>
+                    <td>({{this.roll.total}})</td>
+                </tr>    
+            {{/if}}
+        {{/each}}
+    </table>
+</div>
+<div class="rollResult-result">
+    {{log this.roll}}
+    = {{this.roll.result}}
+</div>
+<div class="rollResult-total">
+    = {{this.roll.total}}
+</div>
+{{#if this.rollConfig.comparison}}
+<div class="rollResult-comparison">
+    {{this.rollConfig.comparison}} {{this.rollConfig.target}} ? {{this.success}}
+</div>
+{{/if}}


### PR DESCRIPTION
fixes #4 

Overhauls the way that rollables are handled on the character sheet.

Previously, rolls were created upon rollable click directly via `Roll.toMessage`. The formula passed into the `Roll` were grabbed straight from the HTML via JQuery. This had several limitations, especially that rolls were effectively hardcoded into the HTML (albeit string concatenation was possible via Handlebars), and the resultant chat message was the stock Foundry roll template (which is not to my liking).

As #4 noted, it was desirable to create some system such that clicking on the rollable would prompt the user for modifiers to the roll. Additionally, a TODO statement near the rollable event listener noted that I wanted a better system to show roll 'failure'/'success' than the ["cs" count success option](https://foundryvtt.com/article/dice-modifiers/).

With this update, the `Roll.toMessage` usage is obviated. Instead, each PC actor will maintain a map of a new item type, `rollConfig`. Each rollable on the character sheet has a unique `rollid`. When the rollable is triggered for the first time, a new `rollConfig` item is added to the map; on subsequent rollable triggers, this id is looked up and the already existing `rollConfig` item is used. These items store the base roll, the comparison type, and the roll target of each roll. Additionally, they store an array of 'modifiers' that are to be applied to the roll. Clicking a rollable opens the newly added `rollConfig`'s item sheet, which has a table used to manipulate the value of the array of modifiers. When the modifiers are to the user's satisfaction, they may click on the 'roll' button on this item sheet.

The roll button creates a new chat message that is templated using a newly added Handlebars partial, `rollResult`. The message displays the resultant roll formula (including all modifiers), the results of each die rolled, a collapsible table of all modifiers applied to the roll, and the final value rolled.

The primary benefit of using this system is that the modifiers of the roll are encoded within an item which is stored in Foundry's backend, meaning that the latest configuration for each individual roll is preserved across reloads. Individual modifiers are given a succinct label and can easily be toggled and deleted. The labels are displayed in the collapsible table within `rollResult` so that other users can identify all modifiers applied to each individual roll. For convenience, shift+clicking the rollable will bypass opening the `rollConfig` sheet and immediately roll using the stored modifiers.