### PR TITLE
refactor rollConfig roll functionality

### DIFF
--- a/system/sheets/actors/pc-sheet.mjs
+++ b/system/sheets/actors/pc-sheet.mjs
@@ -111,6 +111,7 @@ export class TwoNPlayerCharacterActorSheet extends TwoNActorSheet {
             activeEncumbranceRow[0].className = 'encumbranceHighlight';
     }
 
+    /** select contents of input on focus */
     _inputFocus() {
         const el = $(this);
         el.one('mouseup.mouseupSelect', () => {

--- a/system/utils/activateListenersRollResult.mjs
+++ b/system/utils/activateListenersRollResult.mjs
@@ -5,5 +5,8 @@
 export const activateListenersRollResult = (_message, html, _data) => {
     html.find('.rollResult-collapse').click((_ev) => {
         html.find('.rollResult-mods').toggle();
+        if (html.find('.rollResult-mods').css('display') === 'none')
+            html.find('.rollResult-collapse').text('Show all modifiers...');
+        else html.find('.rollResult-collapse').text('Hide all modifiers');
     });
 };

--- a/templates/chats/rollResults/default.html
+++ b/templates/chats/rollResults/default.html
@@ -1,4 +1,6 @@
-<button class="rollResult-collapse">collapse</button>
+{{#if (eq this.rollConfig.mods.length 0)}}
+{{else}}
+<button class="rollResult-collapse">Show all modifiers...</button>
 <div class="rollResult-mods" style="display: none">
     <table>
         <tr>
@@ -15,8 +17,14 @@
                 </tr>    
             {{/if}}
         {{/each}}
+        <tr>
+            <th>Total modification</th>
+            <th></th>
+            <th>{{this.modsSum}}</th>
+        </tr>
     </table>
 </div>
+{{/if}}
 <div class="rollResult-result">
     = {{this.roll.result}}
 </div>

--- a/templates/sheets/items/rollConfig-sheet.html
+++ b/templates/sheets/items/rollConfig-sheet.html
@@ -1,8 +1,20 @@
 <form class="{{cssClass}}" autocomplete="off">
     <div class="rollMods" style="margin:5px;">
+        <table>
+            <tr>
+                <th>Base roll</th>
+                <th>
+                    <input
+                        type="text"
+                        name="system.roll"
+                        value="{{data.system.roll}}"
+                    />
+                </th>
+            </tr>
+        </table>
         <table class="itemTable">
             <tr>
-                <th colspan="5">Roll Modifiers</th>
+                <th colspan="6">Roll Modifiers</th>
             </tr>
             <tr>
                 <th></th>
@@ -10,6 +22,7 @@
                 <th>Mod</th>
                 <th>Active?</th>
                 <th></th>
+                <th>Last val.</th>
             </tr>
             <tbody class="itemTable-sort">
                 {{#each data.system.mods}}
@@ -64,6 +77,7 @@
                         </a>
                     </td>
                     {{/if}}
+                    <td>{{{this.roll.total}}}</td>
                 </tr>
                 {{/each}}
             </tbody>
@@ -73,7 +87,10 @@
         </div>
     </div>
     {{#if data.system.comparison}}
-    <h3>Desired roll: {{data.system.comparison}} {{data.system.target}}</h3>
+    <h3>Desired roll is {{data.system.comparison}} {{data.system.target}}</h3>
     {{/if}}
-    <button class="roll">roll me</button>
+    {{#if data.system.lastRoll}}
+    <h3>Result of last roll: {{data.system.lastRoll.total}}</h3>
+    {{/if}}
+    <button class="roll">Roll {{data.system.rollStr}}</button>
 </form>


### PR DESCRIPTION
fixes #15

Refactors some of the spaghetti mess that was the RollConfig item types' `roll()` function:

- moves roll string building into a different function called from `_updateMods`, so that the string can be displayed on the RollConfig sheet and be updated on mod edit
    - Adds combination of like terms (eg, "2d20 + 1d20 - 3d20" -> "3d20 - 3d20"
-  Cleans up the modifier evaluation loop, mods store their last roll object for rollResult rendering
- Adds results of last roll (and results of individual modifier evaluation) to RollConfig sheet
- Updates text of rollResult expand/collapse button to actually reflect current state

Some future considerations:
- possibly add expand/collapse to RollConfig sheet mods table? or just to `itemTable`s in general
- when evaluating each mod, do some error catching and add reactive form validation to indicate values
- still seriously in need of design/styles, see #6